### PR TITLE
Clears the snapshot field after the results have been displayed

### DIFF
--- a/script.js
+++ b/script.js
@@ -26,6 +26,10 @@ function compareSnapshots() {
         comparison.sort((a, b) => b.NewConnections - a.NewConnections);
 
         displayResults(comparison, snapshot1.timestamp, snapshot2.timestamp);
+
+        // Clear the snapshot fields after displaying the result
+        snapshot1Input.value = '';
+        snapshot2Input.value = '';
     } catch (error) {
         alert('Error parsing snapshots. Please make sure you\'ve pasted valid snapshot data.');
         console.error(error);


### PR DESCRIPTION
With the new fix, the snapshot field gets cleared after the results are displayed. Users can now easily paste more snapshots without having to refresh.
Here's how it looks.
<img width="787" alt="Screenshot 2024-09-02 at 11 15 27 PM" src="https://github.com/user-attachments/assets/cbe35030-b852-458d-914f-7c88059d5317">
